### PR TITLE
User Controller error handling

### DIFF
--- a/RevSpaceWebService/src/main/java/com/revature/revspace/controllers/UserController.java
+++ b/RevSpaceWebService/src/main/java/com/revature/revspace/controllers/UserController.java
@@ -51,6 +51,12 @@ public class UserController
         }
     }
 
+    /**
+     * Adds a given user through a surrounding credentials object
+     * gives a 409 for duplicate username, 422 for incomplete input
+     * @param creds a credentials object represented in JSON
+     * @return the user to be added without updated id
+     */
     @PostMapping(value ="/users", consumes = "application/json")
     @ResponseStatus(HttpStatus.CREATED)
     public User addUser(@RequestBody Credentials creds)
@@ -58,9 +64,18 @@ public class UserController
         User updatedUser;
         try
         {
-            updatedUser = us.add(creds.getUser());
-            cs.add(creds);
-        }catch (Exception e)
+            if(creds.getUser() != null && us.getUserByEmail(creds.getUser().getEmail()) == null)
+            {
+                updatedUser = us.add(creds.getUser());
+                cs.add(creds);
+            }else if(creds.getUser() == null)
+            {
+                throw new ResponseStatusException(HttpStatus.UNPROCESSABLE_ENTITY);
+            }else
+            {
+                throw new ResponseStatusException(HttpStatus.CONFLICT);
+            }
+        }catch (IllegalArgumentException e)
         {
             throw new ResponseStatusException(HttpStatus.UNPROCESSABLE_ENTITY);
         }

--- a/RevSpaceWebService/src/main/java/com/revature/revspace/controllers/UserController.java
+++ b/RevSpaceWebService/src/main/java/com/revature/revspace/controllers/UserController.java
@@ -66,6 +66,7 @@ public class UserController
         try
         {
             if(!Objects.equals(creds.getPassword(), "")
+                    && creds.getPassword() != null
                     && creds.getUser() != null
                     && !Objects.equals(creds.getUser().getEmail(), "")
                     && !Objects.equals(creds.getUser().getFirstName(), "")
@@ -116,6 +117,7 @@ public class UserController
         boolean idFound;
         //parsing int from string, can(should) be done somewhere else
         int safeId;
+        Integer credsId;
         try
         {
             safeId = Integer.parseInt(id);
@@ -123,6 +125,8 @@ public class UserController
         {
             safeId = 0;
         }
+        credsId = cs.getIdByUserId(safeId);
+        cs.delete((credsId != null)?credsId:0);
         idFound = us.delete(safeId);
         if(!idFound)
         {

--- a/RevSpaceWebService/src/main/java/com/revature/revspace/repositories/CredentialsRepo.java
+++ b/RevSpaceWebService/src/main/java/com/revature/revspace/repositories/CredentialsRepo.java
@@ -9,6 +9,7 @@ import org.springframework.stereotype.Repository;
 @Repository
 public interface CredentialsRepo extends CrudRepository<Credentials, Integer>{
     Credentials findByUserEmail(String email);
+    Credentials findByUserUserId(int userId);
 }
 
 

--- a/RevSpaceWebService/src/main/java/com/revature/revspace/services/CredentialsService.java
+++ b/RevSpaceWebService/src/main/java/com/revature/revspace/services/CredentialsService.java
@@ -7,4 +7,11 @@ import com.revature.revspace.repositories.CredentialsRepo;
 public interface CredentialsService extends CrudService<Credentials, Integer, CredentialsRepo> {
 
     Credentials getByEmail(String email);
+
+    /**
+     * gets credentialsId by userId
+     * @param id the userId to search for
+     * @return credentialsId of result if found, 0 if not found
+     */
+    Integer getIdByUserId(int id);
 }

--- a/RevSpaceWebService/src/main/java/com/revature/revspace/services/CredentialsServiceImpl.java
+++ b/RevSpaceWebService/src/main/java/com/revature/revspace/services/CredentialsServiceImpl.java
@@ -26,4 +26,11 @@ public class CredentialsServiceImpl implements CredentialsService{
     public Credentials getByEmail(String email) {
         return credentialsRepo.findByUserEmail(email);
     }
+
+    @Override
+    public Integer getIdByUserId(int id)
+    {
+        Credentials credResult = credentialsRepo.findByUserUserId(id);
+        return (credResult != null)? credResult.getCredentialsId() : 0;
+    }
 }

--- a/RevSpaceWebService/src/main/resources/application.properties
+++ b/RevSpaceWebService/src/main/resources/application.properties
@@ -4,3 +4,4 @@ spring.datasource.username=${DB_USERNAME}
 spring.datasource.password=${DB_PASSWORD}
 spring.jpa.hibernate.ddl-auto=validate
 spring.jpa.database-platform=org.hibernate.dialect.PostgreSQLDialect
+server.error.include-stacktrace=never

--- a/RevSpaceWebService/src/test/java/com/revature/revspace/controllers/UserControllerTests.java
+++ b/RevSpaceWebService/src/test/java/com/revature/revspace/controllers/UserControllerTests.java
@@ -37,6 +37,18 @@ public class UserControllerTests
 	private MockMvc mvc;
 
 	@Test
+	@WithMockUser(username = TEST_EMAIL)
+	void getCurrentUser() throws Exception
+	{
+		User user = ModelGenerators.makeRandomUser();
+
+		Mockito.when(service.getLoggedInUser())
+				.thenReturn(user);
+		ResultActions actions = mvc.perform(MockMvcRequestBuilders.get("/login"));
+		actions.andExpect(MockMvcResultMatchers.status().isOk());
+	}
+
+	@Test
 	@WithMockUser(username=TEST_EMAIL)
 	void getUserById() throws Exception
 	{
@@ -64,6 +76,30 @@ public class UserControllerTests
 	}
 
 	@Test
+	@WithMockUser(username=TEST_EMAIL)
+	void getUserByIdBadDatatype() throws Exception
+	{
+		ResultActions actions = mvc.perform(MockMvcRequestBuilders.get("/users/string")
+				.contentType("application/json")
+				.content("{}"));
+		actions.andExpect(MockMvcResultMatchers.status().is4xxClientError());
+	}
+
+	@Test
+	@WithMockUser(username=TEST_EMAIL)
+	void getUserByIdNotFound() throws Exception
+	{
+		int id = 1;
+
+		Mockito.when(service.get(id))
+				.thenReturn(null);
+		ResultActions actions = mvc.perform(MockMvcRequestBuilders.get("/users/1")
+				.contentType("application/json")
+				.content("{}"));
+		actions.andExpect(MockMvcResultMatchers.status().is4xxClientError());
+	}
+
+	@Test
 	void addUser() throws Exception
 	{
 		Credentials creds = ModelGenerators.makeRandomCredentials();
@@ -74,8 +110,39 @@ public class UserControllerTests
 				.thenReturn(creds);
 		ResultActions actions = mvc.perform(MockMvcRequestBuilders.post("/users")
 			.contentType("application/json")
-			.content("{}"));
+			.content("{\"user\":{\"email\": \"notNullUnique\",\"firstName\": \"notNull\",\"lastName\":\"notNull\"},\"password\":\"notNull\"}"));
 		actions.andExpect(MockMvcResultMatchers.status().isCreated());
+	}
+
+	@Test
+	void addUserBadCredentialsObject() throws Exception
+	{
+		ResultActions actions = mvc.perform(MockMvcRequestBuilders.post("/users")
+				.contentType("application/json")
+				.content("{\"user\":{\"email\": \"notNullUnique\",\"name\": \"notNull\"}}"));
+		actions.andExpect(MockMvcResultMatchers.status().is4xxClientError());
+	}
+
+	@Test
+	void addUserNoUserObject() throws Exception
+	{
+		ResultActions actions = mvc.perform(MockMvcRequestBuilders.post("/users")
+				.contentType("application/json")
+				.content("{\"password\":\"notNull\"}"));
+		actions.andExpect(MockMvcResultMatchers.status().is4xxClientError());
+	}
+
+	@Test
+	void addUserDuplicate() throws Exception
+	{
+		Credentials creds = ModelGenerators.makeRandomCredentials();
+
+		Mockito.when(service.getUserByEmail(creds.getUser().getEmail()))
+				.thenReturn(creds.getUser());
+		ResultActions actions = mvc.perform(MockMvcRequestBuilders.post("/users")
+				.contentType("application/json")
+				.content("{\"user\":{\"email\": \""+creds.getUser().getEmail()+"\",\"firstName\": \"notNull\",\"lastName\":\"notNull\"},\"password\":\"notNull\"}"));
+		actions.andExpect(MockMvcResultMatchers.status().is4xxClientError());
 	}
 
 	@Test
@@ -84,7 +151,7 @@ public class UserControllerTests
 	{
 		User user = ModelGenerators.makeRandomUser();
 
-		Mockito.when(service.add(new User()))
+		Mockito.when(service.update(new User()))
 			.thenReturn(user);
 		ResultActions actions = mvc.perform(MockMvcRequestBuilders.put("/users/0")
 			.contentType("application/json")
@@ -94,15 +161,43 @@ public class UserControllerTests
 
 	@Test
 	@WithMockUser(username=TEST_EMAIL)
+	void updateUserBadId() throws Exception
+	{
+		User user = ModelGenerators.makeRandomUser();
+
+		Mockito.when(service.add(new User()))
+				.thenReturn(user);
+		ResultActions actions = mvc.perform(MockMvcRequestBuilders.put("/users/string")
+				.contentType("application/json")
+				.content("{}"));
+		actions.andExpect(MockMvcResultMatchers.status().is4xxClientError());
+	}
+
+	@Test
+	@WithMockUser(username=TEST_EMAIL)
 	void deleteUser() throws Exception
 	{
 		User user = ModelGenerators.makeRandomUser();
 
-		Mockito.when(service.delete(0))
+		Mockito.when(service.delete(user.getUserId()))
 			.thenReturn(true);
-		ResultActions actions = mvc.perform(MockMvcRequestBuilders.delete("/users/0")
+		ResultActions actions = mvc.perform(MockMvcRequestBuilders.delete("/users/"+user.getUserId())
 			.contentType("application/json")
 			.content("{}"));
 		actions.andExpect(MockMvcResultMatchers.status().isOk());
+	}
+
+	@Test
+	@WithMockUser(username=TEST_EMAIL)
+	void deleteUserBadId() throws Exception
+	{
+		User user = ModelGenerators.makeRandomUser();
+
+		Mockito.when(service.delete(0))
+				.thenReturn(false);
+		ResultActions actions = mvc.perform(MockMvcRequestBuilders.delete("/users/string")
+				.contentType("application/json")
+				.content("{}"));
+		actions.andExpect(MockMvcResultMatchers.status().is4xxClientError());
 	}
 }

--- a/RevSpaceWebService/src/test/java/com/revature/revspace/controllers/UserControllerTests.java
+++ b/RevSpaceWebService/src/test/java/com/revature/revspace/controllers/UserControllerTests.java
@@ -191,9 +191,11 @@ public class UserControllerTests
 	@WithMockUser(username=TEST_EMAIL)
 	void deleteUserBadId() throws Exception
 	{
-		User user = ModelGenerators.makeRandomUser();
+		Credentials creds = ModelGenerators.makeRandomCredentials();
 
 		Mockito.when(service.delete(0))
+				.thenReturn(false);
+		Mockito.when(cs.delete(creds.getCredentialsId()))
 				.thenReturn(false);
 		ResultActions actions = mvc.perform(MockMvcRequestBuilders.delete("/users/string")
 				.contentType("application/json")

--- a/RevSpaceWebService/src/test/java/com/revature/revspace/repositories/CredentialRepoTest.java
+++ b/RevSpaceWebService/src/test/java/com/revature/revspace/repositories/CredentialRepoTest.java
@@ -2,6 +2,7 @@ package com.revature.revspace.repositories;
 
 import com.revature.revspace.models.Credentials;
 import com.revature.revspace.models.User;
+import com.revature.revspace.testutils.ModelGenerators;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.SpringBootTest;
@@ -32,5 +33,20 @@ public class CredentialRepoTest {
 
         assertEquals("abc@email.com", test.getUser().getEmail());
         assertNotNull(test);
+    }
+
+    @Test
+    @Rollback
+    void findByUserId()
+    {
+        Credentials creds = ModelGenerators.makeRandomCredentials();
+        User user = creds.getUser();
+
+        userRepo.save(user);
+        credentialsRepo.save(creds);
+
+        Credentials result = credentialsRepo.findByUserUserId(user.getUserId());
+
+        assertEquals(creds, result);
     }
 }

--- a/RevSpaceWebService/src/test/java/com/revature/revspace/services/CredentialsServiceTest.java
+++ b/RevSpaceWebService/src/test/java/com/revature/revspace/services/CredentialsServiceTest.java
@@ -3,6 +3,7 @@ package com.revature.revspace.services;
 import com.revature.revspace.models.Credentials;
 import com.revature.revspace.models.User;
 import com.revature.revspace.repositories.CredentialsRepo;
+import com.revature.revspace.testutils.ModelGenerators;
 import org.junit.jupiter.api.Test;
 import org.mockito.Mockito;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -27,5 +28,15 @@ public class CredentialsServiceTest {
         Mockito.when(credentialsRepo.findByUserEmail(user.getEmail())).thenReturn(credentials);
         Credentials actual = credentialsService.getByEmail(user.getEmail());
         assertEquals("abc@email.com", actual.getUser().getEmail());
+    }
+
+    @Test
+    void getIdByUserId()
+    {
+        Credentials creds = ModelGenerators.makeRandomCredentials();
+        int id = creds.getUser().getUserId();
+        Mockito.when(credentialsRepo.findByUserUserId(id))
+                .thenReturn(creds);
+        assertEquals(creds.getUser().getUserId(), credentialsService.getIdByUserId(id));
     }
 }


### PR DESCRIPTION
   addUser now gives 409 for a duplicate username,
   422 for improperly formatted JSON objects

   stacktrace is no longer output in JSON response when an exception is thrown
   (is still output in log for 500 errors)

   addUser no longer accepts incomplete objects,
   update throws correct status for id not found vs incomplete object,
   delete throws 404 not found
   100% code coverage for controller
